### PR TITLE
Add vscode-quarkus to USAGE_DATA.md

### DIFF
--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -26,6 +26,7 @@ Red Hat extensions' specific telemetry collection details can be found there:
 * [Dependency Analytics](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/blob/master/Telemetry.md)
 * [OpenShift Connector](https://github.com/redhat-developer/vscode-openshift-tools/blob/master/USAGE_DATA.md)
 * [Project Initializer](https://github.com/redhat-developer/vscode-project-initializer/blob/master/USAGE_DATA.md)
+* [Quarkus](https://github.com/redhat-developer/vscode-quarkus/blob/master/USAGE_DATA.md)
 * [Remote Server Protocol](https://github.com/redhat-developer/vscode-rsp-ui/blob/master/USAGE_DATA.md)
 * [Tekton Pipelines](https://github.com/redhat-developer/vscode-tekton/blob/master/USAGE_DATA.md)
 * [Tooling for Apache Camel K](https://github.com/camel-tooling/vscode-camelk/blob/master/USAGE_DATA.md)


### PR DESCRIPTION
Depends on redhat-developer/vscode-quarkus#343 (merged)

Signed-off-by: David Thompson <davthomp@redhat.com>